### PR TITLE
Migrate test-coverage workflow to d-morrison/gha reusable workflow

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,12 +1,10 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: Test coverage
+
 on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
-
-name: test-coverage
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -14,34 +12,13 @@ concurrency:
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-          architecture: x64
-
-      - uses: quarto-dev/quarto-actions/setup@v2
-
-      - name: Install Mkdocs
-        run: |
-          python3 -m pip install --upgrade pip     # install pip
-          python3 -m pip install mkdocs            # install mkdocs
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: covr
-
-      - name: Test coverage
-        run: covr::codecov()
-        shell: Rscript {0}
+    uses: d-morrison/gha/.github/workflows/test-coverage.yml@v2
+    secrets:
+      # Add CODECOV_TOKEN as a repository secret. Optional for public repos, but
+      # recommended -- tokenless uploads are rate-limited and flaky on PRs.
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    with:
+      # Quarto-website tests gate on `.quarto_is_installed()`; the mkdocs and
+      # docsify/docute tests are self-contained (they set up their own venv
+      # or need no external tool), so no other extra setup is needed.
+      install-quarto: true

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+    branches: [main, master]
   workflow_dispatch:
 
 concurrency:
@@ -12,6 +13,9 @@ concurrency:
 
 jobs:
   test-coverage:
+    # @v2, not @v1 like claude.yml/claude-code-review.yml: test-coverage.yml
+    # only ever shipped at v2 in d-morrison/gha (too new to exist at the
+    # frozen @v1 tag), so there's no @v1 version to pin to instead.
     uses: d-morrison/gha/.github/workflows/test-coverage.yml@v2
     secrets:
       # Add CODECOV_TOKEN as a repository secret. Optional for public repos, but


### PR DESCRIPTION
Closes #15

Replaces the hand-rolled `r-lib/actions` coverage recipe (manual Python/Quarto/Mkdocs/R setup + `covr::codecov()`) in `.github/workflows/test-coverage.yaml` with the shared [`d-morrison/gha`](https://github.com/d-morrison/gha) `test-coverage.yml@v2` reusable workflow, matching the `claude.yml`/`claude-code-review.yml` migration already done in this repo (`dd4663a`).

`install-quarto: true` covers the `quarto_website` tests that gate on `.quarto_is_installed()`. The mkdocs `render_docs` tests create their own venv and pip-install mkdocs at test time, and the docsify/docute tests need no external tool, so no other setup step is needed.

`codecov.yml` at the repo root needs no change.

Note: the `jarl-check` CI job is failing on this PR, but it's pre-existing and unrelated — it flags unused functions in `R/utils.R` and `tests/testthat/helper.R` that aren't touched by this diff, so it would fail identically on `main`.
